### PR TITLE
Use Dictionary Storage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,3 +63,7 @@ matrix:
     # Carthage
     - script:
       - carthage build --no-skip-current
+
+    # CocoaPods
+    - script:
+      - pod lib lint

--- a/Iris.podspec
+++ b/Iris.podspec
@@ -13,13 +13,10 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = "8.0"
   s.ios.frameworks = "UIKit"
-  s.ios.exclude_files = "Iris/NSColor.swift"
 
   s.osx.deployment_target = "10.10"
   s.osx.frameworks = "Cocoa"
-  s.osx.exclude_files = "Iris/UIColor.swift"
 
   s.tvos.deployment_target = "9.0"
   s.tvos.frameworks = "UIKit"
-  s.tvos.exclude_files = "Iris/NSColor.swift"
 end

--- a/Iris.xcodeproj/project.pbxproj
+++ b/Iris.xcodeproj/project.pbxproj
@@ -46,6 +46,9 @@
 		4E76DD7C1BF3A361008D2FF3 /* NSString+MD5.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E76DD7A1BF3A361008D2FF3 /* NSString+MD5.m */; };
 		4E76DD831BF4E2B8008D2FF3 /* ImageOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E76DD821BF4E2B8008D2FF3 /* ImageOptionsTests.swift */; };
 		4E76DD851BF4E319008D2FF3 /* ImgixURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E76DD841BF4E319008D2FF3 /* ImgixURLTests.swift */; };
+		4EB6DF271E3FE6980090B4D9 /* ImageOptionKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EB6DF261E3FE6980090B4D9 /* ImageOptionKey.swift */; };
+		4EB6DF281E3FE6980090B4D9 /* ImageOptionKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EB6DF261E3FE6980090B4D9 /* ImageOptionKey.swift */; };
+		4EB6DF291E3FE6980090B4D9 /* ImageOptionKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EB6DF261E3FE6980090B4D9 /* ImageOptionKey.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -127,6 +130,7 @@
 		4E76DD7A1BF3A361008D2FF3 /* NSString+MD5.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+MD5.m"; sourceTree = "<group>"; };
 		4E76DD821BF4E2B8008D2FF3 /* ImageOptionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageOptionsTests.swift; sourceTree = "<group>"; };
 		4E76DD841BF4E319008D2FF3 /* ImgixURLTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImgixURLTests.swift; sourceTree = "<group>"; };
+		4EB6DF261E3FE6980090B4D9 /* ImageOptionKey.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageOptionKey.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -346,6 +350,7 @@
 			isa = PBXGroup;
 			children = (
 				4E76DD711BF39E3A008D2FF3 /* ImageOptions.swift */,
+				4EB6DF261E3FE6980090B4D9 /* ImageOptionKey.swift */,
 				4E76DD731BF3A042008D2FF3 /* SigningOptions.swift */,
 				4E76DD751BF3A10E008D2FF3 /* NSURL+Iris.swift */,
 				4E76DD791BF3A361008D2FF3 /* NSString+MD5.h */,
@@ -664,6 +669,7 @@
 				3A807E151BF50C4A0083685D /* NSString+MD5.m in Sources */,
 				3B4FBD641E25343500042254 /* UIColor.swift in Sources */,
 				3A807E121BF50C4A0083685D /* ImageOptions.swift in Sources */,
+				4EB6DF281E3FE6980090B4D9 /* ImageOptionKey.swift in Sources */,
 				3A807E141BF50C4A0083685D /* NSURL+Iris.swift in Sources */,
 				3BAC16021DB91250007A9CDD /* Comparable.swift in Sources */,
 				3A807E131BF50C4A0083685D /* SigningOptions.swift in Sources */,
@@ -688,6 +694,7 @@
 				3B4FBD6A1E2535DC00042254 /* NSColor.swift in Sources */,
 				3A807E1A1BF50C4B0083685D /* NSString+MD5.m in Sources */,
 				3A807E171BF50C4B0083685D /* ImageOptions.swift in Sources */,
+				4EB6DF291E3FE6980090B4D9 /* ImageOptionKey.swift in Sources */,
 				3A807E191BF50C4B0083685D /* NSURL+Iris.swift in Sources */,
 				3BAC16031DB91250007A9CDD /* Comparable.swift in Sources */,
 				3A807E181BF50C4B0083685D /* SigningOptions.swift in Sources */,
@@ -712,6 +719,7 @@
 				4E76DD741BF3A042008D2FF3 /* SigningOptions.swift in Sources */,
 				3B4FBD631E25343500042254 /* UIColor.swift in Sources */,
 				4E76DD761BF3A10E008D2FF3 /* NSURL+Iris.swift in Sources */,
+				4EB6DF271E3FE6980090B4D9 /* ImageOptionKey.swift in Sources */,
 				3BB8CBC31DB8112F001496EB /* Comparable.swift in Sources */,
 				4E76DD7C1BF3A361008D2FF3 /* NSString+MD5.m in Sources */,
 				4E76DD721BF39E3A008D2FF3 /* ImageOptions.swift in Sources */,

--- a/Iris.xcodeproj/project.pbxproj
+++ b/Iris.xcodeproj/project.pbxproj
@@ -665,7 +665,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3B4FBD6D1E25404D00042254 /* Deprecated.swift in Sources */,
 				3A807E151BF50C4A0083685D /* NSString+MD5.m in Sources */,
 				3B4FBD641E25343500042254 /* UIColor.swift in Sources */,
 				3A807E121BF50C4A0083685D /* ImageOptions.swift in Sources */,
@@ -673,6 +672,7 @@
 				3A807E141BF50C4A0083685D /* NSURL+Iris.swift in Sources */,
 				3BAC16021DB91250007A9CDD /* Comparable.swift in Sources */,
 				3A807E131BF50C4A0083685D /* SigningOptions.swift in Sources */,
+				3B4FBD6D1E25404D00042254 /* Deprecated.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -690,7 +690,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3B4FBD6E1E25404D00042254 /* Deprecated.swift in Sources */,
 				3B4FBD6A1E2535DC00042254 /* NSColor.swift in Sources */,
 				3A807E1A1BF50C4B0083685D /* NSString+MD5.m in Sources */,
 				3A807E171BF50C4B0083685D /* ImageOptions.swift in Sources */,
@@ -698,6 +697,7 @@
 				3A807E191BF50C4B0083685D /* NSURL+Iris.swift in Sources */,
 				3BAC16031DB91250007A9CDD /* Comparable.swift in Sources */,
 				3A807E181BF50C4B0083685D /* SigningOptions.swift in Sources */,
+				3B4FBD6E1E25404D00042254 /* Deprecated.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -715,7 +715,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3B4FBD6C1E25404D00042254 /* Deprecated.swift in Sources */,
 				4E76DD741BF3A042008D2FF3 /* SigningOptions.swift in Sources */,
 				3B4FBD631E25343500042254 /* UIColor.swift in Sources */,
 				4E76DD761BF3A10E008D2FF3 /* NSURL+Iris.swift in Sources */,
@@ -723,6 +722,7 @@
 				3BB8CBC31DB8112F001496EB /* Comparable.swift in Sources */,
 				4E76DD7C1BF3A361008D2FF3 /* NSString+MD5.m in Sources */,
 				4E76DD721BF39E3A008D2FF3 /* ImageOptions.swift in Sources */,
+				3B4FBD6C1E25404D00042254 /* Deprecated.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Iris.xcodeproj/project.pbxproj
+++ b/Iris.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		3A807E211BF50C580083685D /* ImageOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E76DD821BF4E2B8008D2FF3 /* ImageOptionsTests.swift */; };
 		3A807E221BF50C580083685D /* SigningOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E0E1B181BF507B7002943D0 /* SigningOptionsTests.swift */; };
 		3A807E231BF50CF10083685D /* Iris.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A807E0B1BF50C030083685D /* Iris.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3B074B7E1E4000E400273EDC /* NSColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B4FBD691E2535DC00042254 /* NSColor.swift */; };
+		3B074B7F1E4000E500273EDC /* NSColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B4FBD691E2535DC00042254 /* NSColor.swift */; };
 		3B4FBD631E25343500042254 /* UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B4FBD621E25343500042254 /* UIColor.swift */; };
 		3B4FBD641E25343500042254 /* UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B4FBD621E25343500042254 /* UIColor.swift */; };
 		3B4FBD6A1E2535DC00042254 /* NSColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B4FBD691E2535DC00042254 /* NSColor.swift */; };
@@ -669,6 +671,7 @@
 				3B4FBD641E25343500042254 /* UIColor.swift in Sources */,
 				3A807E121BF50C4A0083685D /* ImageOptions.swift in Sources */,
 				4EB6DF281E3FE6980090B4D9 /* ImageOptionKey.swift in Sources */,
+				3B074B7E1E4000E400273EDC /* NSColor.swift in Sources */,
 				3A807E141BF50C4A0083685D /* NSURL+Iris.swift in Sources */,
 				3BAC16021DB91250007A9CDD /* Comparable.swift in Sources */,
 				3A807E131BF50C4A0083685D /* SigningOptions.swift in Sources */,
@@ -719,6 +722,7 @@
 				3B4FBD631E25343500042254 /* UIColor.swift in Sources */,
 				4E76DD761BF3A10E008D2FF3 /* NSURL+Iris.swift in Sources */,
 				4EB6DF271E3FE6980090B4D9 /* ImageOptionKey.swift in Sources */,
+				3B074B7F1E4000E500273EDC /* NSColor.swift in Sources */,
 				3BB8CBC31DB8112F001496EB /* Comparable.swift in Sources */,
 				4E76DD7C1BF3A361008D2FF3 /* NSString+MD5.m in Sources */,
 				4E76DD721BF39E3A008D2FF3 /* ImageOptions.swift in Sources */,

--- a/Iris/Deprecated.swift
+++ b/Iris/Deprecated.swift
@@ -6,6 +6,14 @@
 //  Copyright © 2017 HODINKEE. All rights reserved.
 //
 
+extension ImageOptions {
+    @available(*, deprecated, renamed: "dpi")
+    public var DPI: Int? {
+        get { return dpi }
+        set { dpi = newValue }
+    }
+}
+
 extension ImageOptions.CropMode {
     @available(*, deprecated, renamed: "top")
     public static var Top: ImageOptions.CropMode { return .top }

--- a/Iris/ImageOptionKey.swift
+++ b/Iris/ImageOptionKey.swift
@@ -6,11 +6,10 @@
 //  Copyright © 2017 HODINKEE. All rights reserved.
 //
 
-import Foundation
-
 enum ImageOptionKey: String {
 
     // MARK: - Adjustment Options
+
     case brightness = "bri"
     case contrast = "con"
     case exposure = "exp"
@@ -24,6 +23,7 @@ enum ImageOptionKey: String {
     case vibrance = "vib"
 
     // MARK: - Size Options
+
     case width = "w"
     case height = "h"
     case fit = "fit"
@@ -32,6 +32,7 @@ enum ImageOptionKey: String {
     case cropRect = "rect"
 
     // MARK: - Format Options
+
     case format = "fm"
     case dpi = "dpi"
     case lossless = "lossless"
@@ -39,9 +40,11 @@ enum ImageOptionKey: String {
     case colorQuantization = "colorquant"
 
     // MARK: - Background Options
+
     case backgroundColor = "bg"
 
     // MARK: - Text Options
+
     case textSize = "txtsize"
     case textColor = "txtclr"
 }

--- a/Iris/ImageOptionKey.swift
+++ b/Iris/ImageOptionKey.swift
@@ -1,0 +1,47 @@
+//
+//  ImageOptionKey.swift
+//  Iris
+//
+//  Created by Jonathan Baker on 1/30/17.
+//  Copyright © 2017 HODINKEE. All rights reserved.
+//
+
+import Foundation
+
+enum ImageOptionKey: String {
+
+    // MARK: - Adjustment Options
+    case brightness = "bri"
+    case contrast = "con"
+    case exposure = "exp"
+    case gamma = "gam"
+    case highlight = "high"
+    case hue = "hue"
+    case invert = "invert"
+    case saturation = "sat"
+    case shadow = "shad"
+    case sharpen = "sharp"
+    case vibrance = "vib"
+
+    // MARK: - Size Options
+    case width = "w"
+    case height = "h"
+    case fit = "fit"
+    case scale = "dpr"
+    case crop = "crop"
+    case cropRect = "rect"
+
+    // MARK: - Format Options
+    case format = "fm"
+    case dpi = "dpi"
+    case lossless = "lossless"
+    case quality = "q"
+    case colorQuantization = "colorquant"
+
+    // MARK: - Background Options
+    case backgroundColor = "bg"
+
+    // MARK: - Text Options
+    case textSize = "txtsize"
+    case textColor = "txtclr"
+}

--- a/Iris/ImageOptions.swift
+++ b/Iris/ImageOptions.swift
@@ -10,359 +10,9 @@ import Foundation
 
 public struct ImageOptions {
 
-    // MARK: - Types
-
-    public enum Format: String {
-        case jpeg = "jpg"
-        case png = "png"
-        case json = "json"
-        case mp4 = "mp4"
-        case webp = "webp"
-    }
-
-    public enum FitMode: String {
-        case crop = "crop"
-        case clip = "clip"
-        case clamp = "clamp"
-        case faceArea = "facearea"
-        case fill = "fill"
-        case max = "max"
-        case min = "min"
-        case scale = "scale"
-    }
-
-    public enum CropMode: String {
-        case top = "top"
-        case bottom = "bottom"
-        case left = "left"
-        case right = "right"
-        case faces = "faces"
-        case entropy = "entropy"
-    }
-
     // MARK: - Properties
 
-    var storage = [ImageOptionKey: Any]()
-
-    // MARK: - Adjustment Properties
-
-    /**
-     Adjusts the brightness of the image.
-
-     Values are clamped to the range `-100...100`.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-bri)
-    */
-    public var brightness: Int? {
-        get { return storage[.brightness] as? Int }
-        set { storage[.brightness] = newValue?.clamped(to: -100...100) }
-    }
-
-    /**
-     Adjusts the contrast of the image.
-
-     Values are clamped to the range `-100...100`.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-con)
-    */
-    public var contrast: Int? {
-        get { return storage[.contrast] as? Int }
-        set { storage[.contrast] = newValue?.clamped(to: -100...100) }
-    }
-
-    /**
-     Adjusts the exposure of the image.
-
-     Values are clamped to the range `-100...100`.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-exp)
-    */
-    public var exposure: Int? {
-        get { return storage[.exposure] as? Int }
-        set { storage[.exposure] = newValue?.clamped(to: -100...100) }
-    }
-
-    /**
-     Adjusts gamma/midtone brightness.
-
-     Values are clamped to the range `-100...100`.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-gam)
-    */
-    public var gamma: Int? {
-        get { return storage[.gamma] as? Int }
-        set { storage[.gamma] = newValue?.clamped(to: -100...100) }
-    }
-
-    /**
-     Adjusts the highlight tonal mapping of an image while preserving 
-     spatial detail.
-
-     Values are clamped to the range `-100...100`.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-high)
-    */
-    public var highlight: Int? {
-        get { return storage[.highlight] as? Int }
-        set { storage[.highlight] = newValue?.clamped(to: -100...100) }
-    }
-
-    /**
-     Changes the overall hue, or tint, of the source pixels.
-
-     Values are clamped to the range `0...359`.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-hue)
-    */
-    public var hue: Int? {
-        get { return storage[.hue] as? Int }
-        set { storage[.hue] = newValue?.clamped(to: 0...359) }
-    }
-
-    /**
-     Inverts all the pixel colors and brightness values within the image
-     producing a negative of the image.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-invert)
-    */
-    public var invert: Bool? {
-        get { return storage[.invert] as? Bool }
-        set { storage[.invert] = newValue }
-    }
-
-    /**
-     Adjusts the saturation of the image.
-
-     Values are clamped to the range `-100...100`.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-sat)
-    */
-    public var saturation: Int? {
-        get { return storage[.saturation] as? Int }
-        set { storage[.saturation] = newValue?.clamped(to: -100...100) }
-    }
-
-    /**
-     Adjusts the shadow tonal mapping of an image while preserving 
-     spatial detail.
-
-     Values are clamped to the range `-100...100`.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-shad)
-    */
-    public var shadow: Int? {
-        get { return storage[.shadow] as? Int }
-        set { storage[.shadow] = newValue?.clamped(to: -100...100) }
-    }
-
-    /**
-     Sharpens the image details using luminance sharpening.
-
-     Values are clamped to the range `0...100`.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-sharp)
-    */
-    public var sharpen: Int? {
-        get { return storage[.sharpen] as? Int }
-        set { storage[.sharpen] = newValue?.clamped(to: 0...100) }
-    }
-
-    /**
-     Adjusts the vibrance of an image while keeping pleasing skin tones.
-
-     Values are clamped to the range `-100...100`.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-vib)
-    */
-    public var vibrance: Int? {
-        get { return storage[.vibrance] as? Int }
-        set { storage[.vibrance] = newValue?.clamped(to: -100...100) }
-    }
-
-
-    // MARK: - Size Properties
-
-    /**
-     The width of the output image.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/size#param-w)
-    */
-    public var width: CGFloat? {
-        get { return storage[.width] as? CGFloat }
-        set { storage[.width] = newValue }
-    }
-
-    /**
-     The height of the output image.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/size#param-h)
-    */
-    public var height: CGFloat? {
-        get { return storage[.height] as? CGFloat }
-        set { storage[.height] = newValue }
-    }
-
-    /**
-     The device pixel ratio to be used.
-     
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/pixeldensity)
-    */
-    public var scale: CGFloat? {
-        get { return storage[.scale] as? CGFloat }
-        set { storage[.scale] = newValue }
-    }
-
-    /**
-     Controls how the output image is fit to its target dimensions.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/size#param-fit)
-    */
-    public var fit: FitMode? {
-        get { return storage[.fit] as? FitMode }
-        set { storage[.fit] = newValue }
-    }
-
-    /**
-     Controls how the input image is aligned when the `fit` property
-     is set to `FitMode.Crop`
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/size#param-crop)
-    */
-    public var crop: [CropMode]? {
-        get { return storage[.crop] as? [CropMode] }
-        set { storage[.crop] = newValue }
-    }
-
-    /**
-     Selects a sub-region (rect) of the source image to use for processing.
-     
-     Value is set equal to `nil` if `CGRect.isNull`, `CGRect.isEmpty`, or `CGRect.isInfinite`
-     returns true.
-     
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/size#param-rect)
-    */
-    public var cropRect: CGRect? {
-        get { return storage[.cropRect] as? CGRect }
-        set {
-            if let rect = newValue, !rect.isNull, !rect.isEmpty, !rect.isInfinite {
-                storage[.cropRect] = rect
-            }
-            else {
-                storage[.cropRect] = nil
-            }
-        }
-    }
-
-
-    // MARK: - Format Properties
-
-    /**
-     The output format to convert the image to.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/format#param-fm)
-    */
-    public var format: Format? {
-        get { return storage[.format] as? Format }
-        set { storage[.format] = newValue }
-    }
-
-    /**
-     The DPI value in the Exif header of the resulting image.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/format#param-dpi)
-    */
-    public var DPI: Int? {
-        get { return storage[.dpi] as? Int }
-        set { storage[.dpi] = newValue }
-    }
-
-    /**
-     Enables or disables lossless compression. Only available when using
-     certain formats.
-     
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/format#param-lossless)
-    */
-    public var lossless: Bool? {
-        get { return storage[.lossless] as? Bool }
-        set { storage[.lossless] = newValue }
-    }
-
-    /**
-     Controls the output quality of lossy file formats. 
-     
-     Values are clamped to the range of `0...100`.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/format#param-q)
-    */
-    public var quality: Int? {
-        get { return storage[.quality] as? Int }
-        set { storage[.quality] = newValue?.clamped(to: 0...100) }
-    }
-
-    /**
-     Limits the amount of colors in a picture using color quantization, which 
-     is a process that reduces the amount of distinct colors in an image while 
-     maintaining a visually-similar image. 
-
-     Values are clamped to the range of `2...256`.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/format#param-colorquant)
-    */
-    public var colorQuantization: Int? {
-        get { return storage[.colorQuantization] as? Int }
-        set { storage[.colorQuantization] = newValue?.clamped(to: 2...256) }
-    }
-
-
-    // MARK: - Background Properties
-
-    /// The background color to use when transparency is encountered. This color
-    /// is also used when using `FitMode.Fill`.
-    ///
-    /// - seealso: [Imgix API Reference](https://www.imgix.com/docs/reference/background#param-bg)
-    public var backgroundColor: Color? {
-        get { return storage[.backgroundColor] as? Color }
-        set { storage[.backgroundColor] = newValue }
-    }
-
-    /// Sets the color of the text.
-    ///
-    /// - seealso: [Imgix Reference](https://docs.imgix.com/apis/url/text/txtclr)
-    public var textColor: Color? {
-        get { return storage[.textColor] as? Color }
-        set { storage[.textColor] = newValue }
-    }
-
-    /// Sets the font size of the text.
-    ///
-    /// - seealso: [Imgix Reference](https://docs.imgix.com/apis/url/text/txtsize)
-    public var textSize: CGFloat? {
-        get { return storage[.textSize] as? CGFloat }
-        set { storage[.textSize] = newValue }
-    }
-
+    fileprivate var storage = [ImageOptionKey: Any]()
 
     // MARK: - Initializers
 
@@ -499,6 +149,356 @@ public struct ImageOptions {
         return items
     }
 }
+
+// MARK: - Adjustment Options
+extension ImageOptions {
+    /**
+     Adjusts the brightness of the image.
+
+     Values are clamped to the range `-100...100`.
+
+     - seealso:
+     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-bri)
+     */
+    public var brightness: Int? {
+        get { return storage[.brightness] as? Int }
+        set { storage[.brightness] = newValue?.clamped(to: -100...100) }
+    }
+
+    /**
+     Adjusts the contrast of the image.
+
+     Values are clamped to the range `-100...100`.
+
+     - seealso:
+     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-con)
+     */
+    public var contrast: Int? {
+        get { return storage[.contrast] as? Int }
+        set { storage[.contrast] = newValue?.clamped(to: -100...100) }
+    }
+
+    /**
+     Adjusts the exposure of the image.
+
+     Values are clamped to the range `-100...100`.
+
+     - seealso:
+     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-exp)
+     */
+    public var exposure: Int? {
+        get { return storage[.exposure] as? Int }
+        set { storage[.exposure] = newValue?.clamped(to: -100...100) }
+    }
+
+    /**
+     Adjusts gamma/midtone brightness.
+
+     Values are clamped to the range `-100...100`.
+
+     - seealso:
+     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-gam)
+     */
+    public var gamma: Int? {
+        get { return storage[.gamma] as? Int }
+        set { storage[.gamma] = newValue?.clamped(to: -100...100) }
+    }
+
+    /**
+     Adjusts the highlight tonal mapping of an image while preserving
+     spatial detail.
+
+     Values are clamped to the range `-100...100`.
+
+     - seealso:
+     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-high)
+     */
+    public var highlight: Int? {
+        get { return storage[.highlight] as? Int }
+        set { storage[.highlight] = newValue?.clamped(to: -100...100) }
+    }
+
+    /**
+     Changes the overall hue, or tint, of the source pixels.
+
+     Values are clamped to the range `0...359`.
+
+     - seealso:
+     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-hue)
+     */
+    public var hue: Int? {
+        get { return storage[.hue] as? Int }
+        set { storage[.hue] = newValue?.clamped(to: 0...359) }
+    }
+
+    /**
+     Inverts all the pixel colors and brightness values within the image
+     producing a negative of the image.
+
+     - seealso:
+     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-invert)
+     */
+    public var invert: Bool? {
+        get { return storage[.invert] as? Bool }
+        set { storage[.invert] = newValue }
+    }
+
+    /**
+     Adjusts the saturation of the image.
+
+     Values are clamped to the range `-100...100`.
+
+     - seealso:
+     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-sat)
+     */
+    public var saturation: Int? {
+        get { return storage[.saturation] as? Int }
+        set { storage[.saturation] = newValue?.clamped(to: -100...100) }
+    }
+
+    /**
+     Adjusts the shadow tonal mapping of an image while preserving
+     spatial detail.
+
+     Values are clamped to the range `-100...100`.
+
+     - seealso:
+     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-shad)
+     */
+    public var shadow: Int? {
+        get { return storage[.shadow] as? Int }
+        set { storage[.shadow] = newValue?.clamped(to: -100...100) }
+    }
+
+    /**
+     Sharpens the image details using luminance sharpening.
+
+     Values are clamped to the range `0...100`.
+
+     - seealso:
+     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-sharp)
+     */
+    public var sharpen: Int? {
+        get { return storage[.sharpen] as? Int }
+        set { storage[.sharpen] = newValue?.clamped(to: 0...100) }
+    }
+
+    /**
+     Adjusts the vibrance of an image while keeping pleasing skin tones.
+
+     Values are clamped to the range `-100...100`.
+
+     - seealso:
+     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-vib)
+     */
+    public var vibrance: Int? {
+        get { return storage[.vibrance] as? Int }
+        set { storage[.vibrance] = newValue?.clamped(to: -100...100) }
+    }
+}
+
+// MARK: - Size Options
+extension ImageOptions {
+    public enum FitMode: String {
+        case crop = "crop"
+        case clip = "clip"
+        case clamp = "clamp"
+        case faceArea = "facearea"
+        case fill = "fill"
+        case max = "max"
+        case min = "min"
+        case scale = "scale"
+    }
+
+    public enum CropMode: String {
+        case top = "top"
+        case bottom = "bottom"
+        case left = "left"
+        case right = "right"
+        case faces = "faces"
+        case entropy = "entropy"
+    }
+
+    /**
+     The width of the output image.
+
+     - seealso:
+     [Imgix API Reference](https://www.imgix.com/docs/reference/size#param-w)
+     */
+    public var width: CGFloat? {
+        get { return storage[.width] as? CGFloat }
+        set { storage[.width] = newValue }
+    }
+
+    /**
+     The height of the output image.
+
+     - seealso:
+     [Imgix API Reference](https://www.imgix.com/docs/reference/size#param-h)
+     */
+    public var height: CGFloat? {
+        get { return storage[.height] as? CGFloat }
+        set { storage[.height] = newValue }
+    }
+
+    /**
+     The device pixel ratio to be used.
+
+     - seealso:
+     [Imgix API Reference](https://www.imgix.com/docs/reference/pixeldensity)
+     */
+    public var scale: CGFloat? {
+        get { return storage[.scale] as? CGFloat }
+        set { storage[.scale] = newValue }
+    }
+
+    /**
+     Controls how the output image is fit to its target dimensions.
+
+     - seealso:
+     [Imgix API Reference](https://www.imgix.com/docs/reference/size#param-fit)
+     */
+    public var fit: FitMode? {
+        get { return storage[.fit] as? FitMode }
+        set { storage[.fit] = newValue }
+    }
+
+    /**
+     Controls how the input image is aligned when the `fit` property
+     is set to `FitMode.Crop`
+
+     - seealso:
+     [Imgix API Reference](https://www.imgix.com/docs/reference/size#param-crop)
+     */
+    public var crop: [CropMode]? {
+        get { return storage[.crop] as? [CropMode] }
+        set { storage[.crop] = newValue }
+    }
+
+    /**
+     Selects a sub-region (rect) of the source image to use for processing.
+
+     Value is set equal to `nil` if `CGRect.isNull`, `CGRect.isEmpty`, or `CGRect.isInfinite`
+     returns true.
+
+     - seealso:
+     [Imgix API Reference](https://www.imgix.com/docs/reference/size#param-rect)
+     */
+    public var cropRect: CGRect? {
+        get { return storage[.cropRect] as? CGRect }
+        set {
+            if let rect = newValue, !rect.isNull, !rect.isEmpty, !rect.isInfinite {
+                storage[.cropRect] = rect
+            }
+            else {
+                storage[.cropRect] = nil
+            }
+        }
+    }
+}
+
+// MARK: - Format Options
+extension ImageOptions {
+    public enum Format: String {
+        case jpeg = "jpg"
+        case png = "png"
+        case json = "json"
+        case mp4 = "mp4"
+        case webp = "webp"
+    }
+
+    /**
+     The output format to convert the image to.
+
+     - seealso:
+     [Imgix API Reference](https://www.imgix.com/docs/reference/format#param-fm)
+     */
+    public var format: Format? {
+        get { return storage[.format] as? Format }
+        set { storage[.format] = newValue }
+    }
+
+    /**
+     The DPI value in the Exif header of the resulting image.
+
+     - seealso:
+     [Imgix API Reference](https://www.imgix.com/docs/reference/format#param-dpi)
+     */
+    public var DPI: Int? {
+        get { return storage[.dpi] as? Int }
+        set { storage[.dpi] = newValue }
+    }
+
+    /**
+     Enables or disables lossless compression. Only available when using
+     certain formats.
+
+     - seealso:
+     [Imgix API Reference](https://www.imgix.com/docs/reference/format#param-lossless)
+     */
+    public var lossless: Bool? {
+        get { return storage[.lossless] as? Bool }
+        set { storage[.lossless] = newValue }
+    }
+
+    /**
+     Controls the output quality of lossy file formats.
+
+     Values are clamped to the range of `0...100`.
+
+     - seealso:
+     [Imgix API Reference](https://www.imgix.com/docs/reference/format#param-q)
+     */
+    public var quality: Int? {
+        get { return storage[.quality] as? Int }
+        set { storage[.quality] = newValue?.clamped(to: 0...100) }
+    }
+
+    /**
+     Limits the amount of colors in a picture using color quantization, which
+     is a process that reduces the amount of distinct colors in an image while
+     maintaining a visually-similar image.
+
+     Values are clamped to the range of `2...256`.
+
+     - seealso:
+     [Imgix API Reference](https://www.imgix.com/docs/reference/format#param-colorquant)
+     */
+    public var colorQuantization: Int? {
+        get { return storage[.colorQuantization] as? Int }
+        set { storage[.colorQuantization] = newValue?.clamped(to: 2...256) }
+    }
+}
+
+// MARK: - Background Options
+extension ImageOptions {
+    /// The background color to use when transparency is encountered. This color
+    /// is also used when using `FitMode.Fill`.
+    ///
+    /// - seealso: [Imgix API Reference](https://www.imgix.com/docs/reference/background#param-bg)
+    public var backgroundColor: Color? {
+        get { return storage[.backgroundColor] as? Color }
+        set { storage[.backgroundColor] = newValue }
+    }
+
+    /// Sets the color of the text.
+    ///
+    /// - seealso: [Imgix Reference](https://docs.imgix.com/apis/url/text/txtclr)
+    public var textColor: Color? {
+        get { return storage[.textColor] as? Color }
+        set { storage[.textColor] = newValue }
+    }
+
+    /// Sets the font size of the text.
+    ///
+    /// - seealso: [Imgix Reference](https://docs.imgix.com/apis/url/text/txtsize)
+    public var textSize: CGFloat? {
+        get { return storage[.textSize] as? CGFloat }
+        set { storage[.textSize] = newValue }
+    }
+}
+
+// MARK: - Equatable
 
 extension ImageOptions: Equatable {}
 

--- a/Iris/ImageOptions.swift
+++ b/Iris/ImageOptions.swift
@@ -40,21 +40,24 @@ public struct ImageOptions: Equatable {
         case entropy = "entropy"
     }
 
+    // MARK: - Properties
+
+    var storage = [ImageOptionKey: Any]()
+
     // MARK: - Adjustment Properties
 
     /**
      Adjusts the brightness of the image.
-    
+
      Values are clamped to the range `-100...100`.
 
      - seealso:
      [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-bri)
     */
     public var brightness: Int? {
-        get { return _brightness }
-        set { _brightness = newValue?.clamped(to: -100...100) }
+        get { return storage[.brightness] as? Int }
+        set { storage[.brightness] = newValue?.clamped(to: -100...100) }
     }
-    private var _brightness: Int?
 
     /**
      Adjusts the contrast of the image.
@@ -65,10 +68,9 @@ public struct ImageOptions: Equatable {
      [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-con)
     */
     public var contrast: Int? {
-        get { return _contrast }
-        set { _contrast = newValue?.clamped(to: -100...100) }
+        get { return storage[.contrast] as? Int }
+        set { storage[.contrast] = newValue?.clamped(to: -100...100) }
     }
-    private var _contrast: Int?
 
     /**
      Adjusts the exposure of the image.
@@ -79,10 +81,9 @@ public struct ImageOptions: Equatable {
      [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-exp)
     */
     public var exposure: Int? {
-        get { return _exposure }
-        set { _exposure = newValue?.clamped(to: -100...100) }
+        get { return storage[.exposure] as? Int }
+        set { storage[.exposure] = newValue?.clamped(to: -100...100) }
     }
-    private var _exposure: Int?
 
     /**
      Adjusts gamma/midtone brightness.
@@ -93,10 +94,9 @@ public struct ImageOptions: Equatable {
      [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-gam)
     */
     public var gamma: Int? {
-        get { return _gamma }
-        set { _gamma = newValue?.clamped(to: -100...100) }
+        get { return storage[.gamma] as? Int }
+        set { storage[.gamma] = newValue?.clamped(to: -100...100) }
     }
-    private var _gamma: Int?
 
     /**
      Adjusts the highlight tonal mapping of an image while preserving 
@@ -108,10 +108,9 @@ public struct ImageOptions: Equatable {
      [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-high)
     */
     public var highlight: Int? {
-        get { return _highlight }
-        set { _highlight = newValue?.clamped(to: -100...100) }
+        get { return storage[.highlight] as? Int }
+        set { storage[.highlight] = newValue?.clamped(to: -100...100) }
     }
-    private var _highlight: Int?
 
     /**
      Changes the overall hue, or tint, of the source pixels.
@@ -122,10 +121,9 @@ public struct ImageOptions: Equatable {
      [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-hue)
     */
     public var hue: Int? {
-        get { return _hue }
-        set { _hue = newValue?.clamped(to: 0...359) }
+        get { return storage[.hue] as? Int }
+        set { storage[.hue] = newValue?.clamped(to: 0...359) }
     }
-    private var _hue: Int?
 
     /**
      Inverts all the pixel colors and brightness values within the image
@@ -134,7 +132,10 @@ public struct ImageOptions: Equatable {
      - seealso:
      [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-invert)
     */
-    public var invert: Bool?
+    public var invert: Bool? {
+        get { return storage[.invert] as? Bool }
+        set { storage[.invert] = newValue }
+    }
 
     /**
      Adjusts the saturation of the image.
@@ -145,10 +146,9 @@ public struct ImageOptions: Equatable {
      [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-sat)
     */
     public var saturation: Int? {
-        get { return _saturation }
-        set { _saturation = newValue?.clamped(to: -100...100) }
+        get { return storage[.saturation] as? Int }
+        set { storage[.saturation] = newValue?.clamped(to: -100...100) }
     }
-    private var _saturation: Int?
 
     /**
      Adjusts the shadow tonal mapping of an image while preserving 
@@ -160,10 +160,9 @@ public struct ImageOptions: Equatable {
      [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-shad)
     */
     public var shadow: Int? {
-        get { return _shadow }
-        set { _shadow = newValue?.clamped(to: -100...100) }
+        get { return storage[.shadow] as? Int }
+        set { storage[.shadow] = newValue?.clamped(to: -100...100) }
     }
-    private var _shadow: Int?
 
     /**
      Sharpens the image details using luminance sharpening.
@@ -174,10 +173,9 @@ public struct ImageOptions: Equatable {
      [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-sharp)
     */
     public var sharpen: Int? {
-        get { return _sharpen }
-        set { _sharpen = newValue?.clamped(to: 0...100) }
+        get { return storage[.sharpen] as? Int }
+        set { storage[.sharpen] = newValue?.clamped(to: 0...100) }
     }
-    private var _sharpen: Int?
 
     /**
      Adjusts the vibrance of an image while keeping pleasing skin tones.
@@ -188,10 +186,9 @@ public struct ImageOptions: Equatable {
      [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-vib)
     */
     public var vibrance: Int? {
-        get { return _vibrance }
-        set { _vibrance = newValue?.clamped(to: -100...100) }
+        get { return storage[.vibrance] as? Int }
+        set { storage[.vibrance] = newValue?.clamped(to: -100...100) }
     }
-    private var _vibrance: Int?
 
 
     // MARK: - Size Properties
@@ -202,7 +199,10 @@ public struct ImageOptions: Equatable {
      - seealso:
      [Imgix API Reference](https://www.imgix.com/docs/reference/size#param-w)
     */
-    public var width: CGFloat?
+    public var width: CGFloat? {
+        get { return storage[.width] as? CGFloat }
+        set { storage[.width] = newValue }
+    }
 
     /**
      The height of the output image.
@@ -210,7 +210,10 @@ public struct ImageOptions: Equatable {
      - seealso:
      [Imgix API Reference](https://www.imgix.com/docs/reference/size#param-h)
     */
-    public var height: CGFloat?
+    public var height: CGFloat? {
+        get { return storage[.height] as? CGFloat }
+        set { storage[.height] = newValue }
+    }
 
     /**
      The device pixel ratio to be used.
@@ -218,7 +221,10 @@ public struct ImageOptions: Equatable {
      - seealso:
      [Imgix API Reference](https://www.imgix.com/docs/reference/pixeldensity)
     */
-    public var scale: CGFloat?
+    public var scale: CGFloat? {
+        get { return storage[.scale] as? CGFloat }
+        set { storage[.scale] = newValue }
+    }
 
     /**
      Controls how the output image is fit to its target dimensions.
@@ -226,7 +232,10 @@ public struct ImageOptions: Equatable {
      - seealso:
      [Imgix API Reference](https://www.imgix.com/docs/reference/size#param-fit)
     */
-    public var fit: FitMode?
+    public var fit: FitMode? {
+        get { return storage[.fit] as? FitMode }
+        set { storage[.fit] = newValue }
+    }
 
     /**
      Controls how the input image is aligned when the `fit` property
@@ -235,7 +244,10 @@ public struct ImageOptions: Equatable {
      - seealso:
      [Imgix API Reference](https://www.imgix.com/docs/reference/size#param-crop)
     */
-    public var crop: [CropMode]?
+    public var crop: [CropMode]? {
+        get { return storage[.crop] as? [CropMode] }
+        set { storage[.crop] = newValue }
+    }
 
     /**
      Selects a sub-region (rect) of the source image to use for processing.
@@ -247,17 +259,16 @@ public struct ImageOptions: Equatable {
      [Imgix API Reference](https://www.imgix.com/docs/reference/size#param-rect)
     */
     public var cropRect: CGRect? {
-        get { return _cropRect }
+        get { return storage[.cropRect] as? CGRect }
         set {
             if let rect = newValue, !rect.isNull, !rect.isEmpty, !rect.isInfinite {
-                _cropRect = rect
+                storage[.cropRect] = rect
             }
             else {
-                _cropRect = nil
+                storage[.cropRect] = nil
             }
         }
     }
-    private var _cropRect: CGRect?
 
 
     // MARK: - Format Properties
@@ -268,7 +279,10 @@ public struct ImageOptions: Equatable {
      - seealso:
      [Imgix API Reference](https://www.imgix.com/docs/reference/format#param-fm)
     */
-    public var format: Format?
+    public var format: Format? {
+        get { return storage[.format] as? Format }
+        set { storage[.format] = newValue }
+    }
 
     /**
      The DPI value in the Exif header of the resulting image.
@@ -276,7 +290,10 @@ public struct ImageOptions: Equatable {
      - seealso:
      [Imgix API Reference](https://www.imgix.com/docs/reference/format#param-dpi)
     */
-    public var DPI: Int?
+    public var DPI: Int? {
+        get { return storage[.dpi] as? Int }
+        set { storage[.dpi] = newValue }
+    }
 
     /**
      Enables or disables lossless compression. Only available when using
@@ -285,7 +302,10 @@ public struct ImageOptions: Equatable {
      - seealso:
      [Imgix API Reference](https://www.imgix.com/docs/reference/format#param-lossless)
     */
-    public var lossless: Bool?
+    public var lossless: Bool? {
+        get { return storage[.lossless] as? Bool }
+        set { storage[.lossless] = newValue }
+    }
 
     /**
      Controls the output quality of lossy file formats. 
@@ -296,10 +316,9 @@ public struct ImageOptions: Equatable {
      [Imgix API Reference](https://www.imgix.com/docs/reference/format#param-q)
     */
     public var quality: Int? {
-        get { return _quality }
-        set { _quality = newValue?.clamped(to: 0...100) }
+        get { return storage[.quality] as? Int }
+        set { storage[.quality] = newValue?.clamped(to: 0...100) }
     }
-    private var _quality: Int?
 
     /**
      Limits the amount of colors in a picture using color quantization, which 
@@ -312,10 +331,9 @@ public struct ImageOptions: Equatable {
      [Imgix API Reference](https://www.imgix.com/docs/reference/format#param-colorquant)
     */
     public var colorQuantization: Int? {
-        get { return _colorQuantization }
-        set { _colorQuantization = newValue?.clamped(to: 2...256) }
+        get { return storage[.colorQuantization] as? Int }
+        set { storage[.colorQuantization] = newValue?.clamped(to: 2...256) }
     }
-    private var _colorQuantization: Int?
 
 
     // MARK: - Background Properties
@@ -324,18 +342,26 @@ public struct ImageOptions: Equatable {
     /// is also used when using `FitMode.Fill`.
     ///
     /// - seealso: [Imgix API Reference](https://www.imgix.com/docs/reference/background#param-bg)
-    public var backgroundColor: Color?
-
+    public var backgroundColor: Color? {
+        get { return storage[.backgroundColor] as? Color }
+        set { storage[.backgroundColor] = newValue }
+    }
 
     /// Sets the color of the text.
     ///
     /// - seealso: [Imgix Reference](https://docs.imgix.com/apis/url/text/txtclr)
-    public var textColor: Color?
+    public var textColor: Color? {
+        get { return storage[.textColor] as? Color }
+        set { storage[.textColor] = newValue }
+    }
 
     /// Sets the font size of the text.
     ///
     /// - seealso: [Imgix Reference](https://docs.imgix.com/apis/url/text/txtsize)
-    public var textSize: CGFloat?
+    public var textSize: CGFloat? {
+        get { return storage[.textSize] as? CGFloat }
+        set { storage[.textSize] = newValue }
+    }
 
 
     // MARK: - Initializers

--- a/Iris/ImageOptions.swift
+++ b/Iris/ImageOptions.swift
@@ -10,6 +10,37 @@ import Foundation
 
 public struct ImageOptions {
 
+    // MARK: - Types
+
+    public enum FitMode: String {
+        case crop = "crop"
+        case clip = "clip"
+        case clamp = "clamp"
+        case faceArea = "facearea"
+        case fill = "fill"
+        case max = "max"
+        case min = "min"
+        case scale = "scale"
+    }
+
+    public enum CropMode: String {
+        case top = "top"
+        case bottom = "bottom"
+        case left = "left"
+        case right = "right"
+        case faces = "faces"
+        case entropy = "entropy"
+    }
+
+    public enum Format: String {
+        case jpeg = "jpg"
+        case png = "png"
+        case json = "json"
+        case mp4 = "mp4"
+        case webp = "webp"
+    }
+    
+
     // MARK: - Properties
 
     fileprivate var storage = [ImageOptionKey: Any]()
@@ -256,25 +287,6 @@ extension ImageOptions {
 // MARK: - Size Options
 
 extension ImageOptions {
-    public enum FitMode: String {
-        case crop = "crop"
-        case clip = "clip"
-        case clamp = "clamp"
-        case faceArea = "facearea"
-        case fill = "fill"
-        case max = "max"
-        case min = "min"
-        case scale = "scale"
-    }
-
-    public enum CropMode: String {
-        case top = "top"
-        case bottom = "bottom"
-        case left = "left"
-        case right = "right"
-        case faces = "faces"
-        case entropy = "entropy"
-    }
 
     /// The width of the output image.
     ///
@@ -337,13 +349,6 @@ extension ImageOptions {
 // MARK: - Format Options
 
 extension ImageOptions {
-    public enum Format: String {
-        case jpeg = "jpg"
-        case png = "png"
-        case json = "json"
-        case mp4 = "mp4"
-        case webp = "webp"
-    }
 
     /// The output format to convert the image to.
     ///

--- a/Iris/ImageOptions.swift
+++ b/Iris/ImageOptions.swift
@@ -65,115 +65,119 @@ public struct ImageOptions {
     public var queryItems: [URLQueryItem] {
         var items = [URLQueryItem]()
 
+        func queryItem(forKey key: ImageOptionKey, value: String) -> URLQueryItem {
+            return URLQueryItem(name: key.rawValue, value: value)
+        }
+
         // Adjustment Properties
 
         if let value = brightness {
-            items.append(URLQueryItem(name: "bri", value: String(value)))
+            items.append(queryItem(forKey: .brightness, value: String(value)))
         }
 
         if let value = contrast {
-            items.append(URLQueryItem(name: "con", value: String(value)))
+            items.append(queryItem(forKey: .contrast, value: String(value)))
         }
 
         if let value = exposure {
-            items.append(URLQueryItem(name: "exp", value: String(value)))
+            items.append(queryItem(forKey: .exposure, value: String(value)))
         }
 
         if let value = gamma {
-            items.append(URLQueryItem(name: "gam", value: String(value)))
+            items.append(queryItem(forKey: .gamma, value: String(value)))
         }
 
         if let value = highlight {
-            items.append(URLQueryItem(name: "high", value: String(value)))
+            items.append(queryItem(forKey: .highlight, value: String(value)))
         }
 
         if let value = hue {
-            items.append(URLQueryItem(name: "hue", value: String(value)))
+            items.append(queryItem(forKey: .hue, value: String(value)))
         }
 
         if let value = invert {
-            items.append(URLQueryItem(name: "invert", value: String(value)))
+            items.append(queryItem(forKey: .invert, value: String(value)))
         }
 
         if let value = saturation {
-            items.append(URLQueryItem(name: "sat", value: String(value)))
+            items.append(queryItem(forKey: .saturation, value: String(value)))
         }
 
         if let value = shadow {
-            items.append(URLQueryItem(name: "shad", value: String(value)))
+            items.append(queryItem(forKey: .shadow, value: String(value)))
         }
 
         if let value = sharpen {
-            items.append(URLQueryItem(name: "sharp", value: String(value)))
+            items.append(queryItem(forKey: .sharpen, value: String(value)))
         }
 
         if let value = vibrance {
-            items.append(URLQueryItem(name: "vib", value: String(value)))
+            items.append(queryItem(forKey: .vibrance, value: String(value)))
         }
 
         // Size Properties
 
         if let value = width {
-            items.append(URLQueryItem(name: "w", value: String(describing: value)))
+            items.append(queryItem(forKey: .width, value: String(describing: value)))
         }
 
         if let value = height {
-            items.append(URLQueryItem(name: "h", value: String(describing: value)))
+            items.append(queryItem(forKey: .height, value: String(describing: value)))
         }
 
         if let value = fit {
-            items.append(URLQueryItem(name: "fit", value: value.rawValue))
+            items.append(queryItem(forKey: .fit, value: value.rawValue))
         }
 
         if let value = scale {
-            items.append(URLQueryItem(name: "dpr", value: String(describing: value)))
+            items.append(queryItem(forKey: .scale, value: String(describing: value)))
         }
 
         if let value = crop {
-            items.append(URLQueryItem(name: "crop", value: value.map({ $0.rawValue }).joined(separator: ",")))
+            items.append(queryItem(forKey: .crop, value: value.map({ $0.rawValue }).joined(separator: ",")))
         }
 
         if let value = cropRect {
             let serialized = "\(value.origin.x),\(value.origin.y),\(value.width),\(value.height)"
-            items.append(URLQueryItem(name: "rect", value: serialized))
+            items.append(queryItem(forKey: .cropRect, value: serialized))
         }
 
         // Format Properties
 
         if let value = format {
-            items.append(URLQueryItem(name: "fm", value: value.rawValue))
+            items.append(queryItem(forKey: .format, value: value.rawValue))
         }
 
         if let value = DPI {
-            items.append(URLQueryItem(name: "dpi", value: String(value)))
+            items.append(queryItem(forKey: .dpi, value: String(value)))
         }
 
         if let value = lossless {
-            items.append(URLQueryItem(name: "lossless", value: String(value)))
+            items.append(queryItem(forKey: .lossless, value: String(value)))
         }
 
         if let value = quality {
-            items.append(URLQueryItem(name: "q", value: String(value)))
+            items.append(queryItem(forKey: .quality, value: String(value)))
         }
 
         if let value = colorQuantization {
-            items.append(URLQueryItem(name: "colorquant", value: String(value)))
+            items.append(queryItem(forKey: .colorQuantization, value: String(value)))
         }
 
         // Background Properties
 
         if let value = backgroundColor, let hex = value.hexadecimalColorString {
-            items.append(URLQueryItem(name: "bg", value: hex))
+            items.append(queryItem(forKey: .backgroundColor, value: hex))
         }
 
         // Text properties
 
         if let value = textColor, let hexadecimalString = value.hexadecimalColorString {
-            items.append(URLQueryItem(name: "txtclr", value: hexadecimalString))
+            items.append(queryItem(forKey: .textColor, value: hexadecimalString))
         }
 
         if let value = textSize {
-            items.append(URLQueryItem(name: "txtsize", value: String(describing: value)))
+            items.append(queryItem(forKey: .textSize, value: String(describing: value)))
         }
 
         return items

--- a/Iris/ImageOptions.swift
+++ b/Iris/ImageOptions.swift
@@ -14,6 +14,7 @@ public struct ImageOptions {
 
     fileprivate var storage = [ImageOptionKey: Any]()
 
+
     // MARK: - Initializers
 
     public init(format: Format? = nil, width: CGFloat? = nil, height: CGFloat? = nil, scale: CGFloat? = nil, fit: FitMode? = nil, crop: [CropMode]? = nil) {
@@ -28,10 +29,8 @@ public struct ImageOptions {
 
     // MARK: - Public
 
-    /**
-     The configured options as `[NSURLQueryItem]`, suitable for use
-     with `NSURLComponents`.
-    */
+    /// An array of query items that can be used in conjunction with an instance
+    /// of `URLComponents` to generate an image URL.
     public var queryItems: [URLQueryItem] {
         var items = [URLQueryItem]()
 
@@ -151,146 +150,103 @@ public struct ImageOptions {
 }
 
 // MARK: - Adjustment Options
+
 extension ImageOptions {
-    /**
-     Adjusts the brightness of the image.
 
-     Values are clamped to the range `-100...100`.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-bri)
-     */
+    /// Adjusts the brightness of the image. Values are clamped to the range
+    /// `-100...100`.
+    ///
+    /// - seealso: [Imgix Reference](https://www.imgix.com/docs/reference/adjustment#param-bri)
     public var brightness: Int? {
         get { return storage[.brightness] as? Int }
         set { storage[.brightness] = newValue?.clamped(to: -100...100) }
     }
 
-    /**
-     Adjusts the contrast of the image.
-
-     Values are clamped to the range `-100...100`.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-con)
-     */
+    /// Adjusts the contrast of the image. Values are clamped to the range
+    /// `-100...100`.
+    ///
+    /// - seealso: [Imgix Reference](https://www.imgix.com/docs/reference/adjustment#param-con)
     public var contrast: Int? {
         get { return storage[.contrast] as? Int }
         set { storage[.contrast] = newValue?.clamped(to: -100...100) }
     }
 
-    /**
-     Adjusts the exposure of the image.
-
-     Values are clamped to the range `-100...100`.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-exp)
-     */
+    /// Adjusts the exposure of the image. Values are clamped to the range
+    /// `-100...100`.
+    ///
+    /// - seealso: [Imgix Reference](https://www.imgix.com/docs/reference/adjustment#param-exp)
     public var exposure: Int? {
         get { return storage[.exposure] as? Int }
         set { storage[.exposure] = newValue?.clamped(to: -100...100) }
     }
 
-    /**
-     Adjusts gamma/midtone brightness.
-
-     Values are clamped to the range `-100...100`.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-gam)
-     */
+    ///Adjusts gamma/midtone brightness. Values are clamped to the range
+    /// `-100...100`.
+    ///
+    /// - seealso: [Imgix Reference](https://www.imgix.com/docs/reference/adjustment#param-gam)
     public var gamma: Int? {
         get { return storage[.gamma] as? Int }
         set { storage[.gamma] = newValue?.clamped(to: -100...100) }
     }
 
-    /**
-     Adjusts the highlight tonal mapping of an image while preserving
-     spatial detail.
-
-     Values are clamped to the range `-100...100`.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-high)
-     */
+    /// Adjusts the highlight tonal mapping of an image while preserving spatial
+    /// detail. Values are clamped to the range `-100...100`.
+    ///
+    /// - seealso: [Imgix Reference](https://www.imgix.com/docs/reference/adjustment#param-high)
     public var highlight: Int? {
         get { return storage[.highlight] as? Int }
         set { storage[.highlight] = newValue?.clamped(to: -100...100) }
     }
 
-    /**
-     Changes the overall hue, or tint, of the source pixels.
-
-     Values are clamped to the range `0...359`.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-hue)
-     */
+    /// Changes the overall hue, or tint, of the source pixels. Values are
+    /// clamped to the range `0...359`.
+    ///
+    /// - seealso: [Imgix Reference](https://www.imgix.com/docs/reference/adjustment#param-hue)
     public var hue: Int? {
         get { return storage[.hue] as? Int }
         set { storage[.hue] = newValue?.clamped(to: 0...359) }
     }
 
-    /**
-     Inverts all the pixel colors and brightness values within the image
-     producing a negative of the image.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-invert)
-     */
+    /// Inverts all the pixel colors and brightness values within the image
+    /// producing a negative of the image.
+    ///
+    /// - seealso: [Imgix Reference](https://www.imgix.com/docs/reference/adjustment#param-invert)
     public var invert: Bool? {
         get { return storage[.invert] as? Bool }
         set { storage[.invert] = newValue }
     }
 
-    /**
-     Adjusts the saturation of the image.
-
-     Values are clamped to the range `-100...100`.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-sat)
-     */
+    /// Adjusts the saturation of the image. Values are clamped to the range
+    /// `-100...100`.
+    ///
+    /// - seealso: [Imgix Reference](https://www.imgix.com/docs/reference/adjustment#param-sat)
     public var saturation: Int? {
         get { return storage[.saturation] as? Int }
         set { storage[.saturation] = newValue?.clamped(to: -100...100) }
     }
 
-    /**
-     Adjusts the shadow tonal mapping of an image while preserving
-     spatial detail.
-
-     Values are clamped to the range `-100...100`.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-shad)
-     */
+    /// Adjusts the shadow tonal mapping of an image while preserving spatial
+    /// detail. Values are clamped to the range `-100...100`.
+    ///
+    /// - seealso: [Imgix Reference](https://www.imgix.com/docs/reference/adjustment#param-shad)
     public var shadow: Int? {
         get { return storage[.shadow] as? Int }
         set { storage[.shadow] = newValue?.clamped(to: -100...100) }
     }
 
-    /**
-     Sharpens the image details using luminance sharpening.
-
-     Values are clamped to the range `0...100`.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-sharp)
-     */
+    /// Sharpens the image details using luminance sharpening. Values are
+    /// clamped to the range `0...100`.
+    ///
+    /// - seealso: [Imgix Reference](https://www.imgix.com/docs/reference/adjustment#param-sharp)
     public var sharpen: Int? {
         get { return storage[.sharpen] as? Int }
         set { storage[.sharpen] = newValue?.clamped(to: 0...100) }
     }
 
-    /**
-     Adjusts the vibrance of an image while keeping pleasing skin tones.
-
-     Values are clamped to the range `-100...100`.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/adjustment#param-vib)
-     */
+    /// Adjusts the vibrance of an image while keeping pleasing skin tones.
+    /// Values are clamped to the range `-100...100`.
+    ///
+    /// - seealso: [Imgix Reference](https://www.imgix.com/docs/reference/adjustment#param-vib)
     public var vibrance: Int? {
         get { return storage[.vibrance] as? Int }
         set { storage[.vibrance] = newValue?.clamped(to: -100...100) }
@@ -298,6 +254,7 @@ extension ImageOptions {
 }
 
 // MARK: - Size Options
+
 extension ImageOptions {
     public enum FitMode: String {
         case crop = "crop"
@@ -319,71 +276,51 @@ extension ImageOptions {
         case entropy = "entropy"
     }
 
-    /**
-     The width of the output image.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/size#param-w)
-     */
+    /// The width of the output image.
+    ///
+    /// - seealso: [Imgix Reference](https://www.imgix.com/docs/reference/size#param-w)
     public var width: CGFloat? {
         get { return storage[.width] as? CGFloat }
         set { storage[.width] = newValue }
     }
 
-    /**
-     The height of the output image.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/size#param-h)
-     */
+    /// The height of the output image.
+    ///
+    /// - seealso: [Imgix Reference](https://www.imgix.com/docs/reference/size#param-h)
     public var height: CGFloat? {
         get { return storage[.height] as? CGFloat }
         set { storage[.height] = newValue }
     }
 
-    /**
-     The device pixel ratio to be used.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/pixeldensity)
-     */
+    /// The device pixel ratio to be used.
+    ///
+    /// - seealso: [Imgix Reference](https://www.imgix.com/docs/reference/pixeldensity)
     public var scale: CGFloat? {
         get { return storage[.scale] as? CGFloat }
         set { storage[.scale] = newValue }
     }
 
-    /**
-     Controls how the output image is fit to its target dimensions.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/size#param-fit)
-     */
+    /// Controls how the output image is fit to its target dimensions.
+    ///
+    /// - seealso: [Imgix Reference](https://www.imgix.com/docs/reference/size#param-fit)
     public var fit: FitMode? {
         get { return storage[.fit] as? FitMode }
         set { storage[.fit] = newValue }
     }
 
-    /**
-     Controls how the input image is aligned when the `fit` property
-     is set to `FitMode.Crop`
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/size#param-crop)
-     */
+    /// Controls how the input image is aligned when the `fit` property is set
+    /// to `FitMode.crop`
+    ///
+    /// - seealso: [Imgix Reference](https://www.imgix.com/docs/reference/size#param-crop)
     public var crop: [CropMode]? {
         get { return storage[.crop] as? [CropMode] }
         set { storage[.crop] = newValue }
     }
 
-    /**
-     Selects a sub-region (rect) of the source image to use for processing.
-
-     Value is set equal to `nil` if `CGRect.isNull`, `CGRect.isEmpty`, or `CGRect.isInfinite`
-     returns true.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/size#param-rect)
-     */
+    /// Selects a sub-region of the source image to use for processing. The
+    /// value is set to `nil` if the rect is null, empty, or infinite.
+    ///
+    /// - seealso: [Imgix Reference](https://www.imgix.com/docs/reference/size#param-rect)
     public var cropRect: CGRect? {
         get { return storage[.cropRect] as? CGRect }
         set {
@@ -398,6 +335,7 @@ extension ImageOptions {
 }
 
 // MARK: - Format Options
+
 extension ImageOptions {
     public enum Format: String {
         case jpeg = "jpg"
@@ -407,63 +345,45 @@ extension ImageOptions {
         case webp = "webp"
     }
 
-    /**
-     The output format to convert the image to.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/format#param-fm)
-     */
+    /// The output format to convert the image to.
+    ///
+    /// - seealso: [Imgix Reference](https://www.imgix.com/docs/reference/format#param-fm)
     public var format: Format? {
         get { return storage[.format] as? Format }
         set { storage[.format] = newValue }
     }
 
-    /**
-     The DPI value in the Exif header of the resulting image.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/format#param-dpi)
-     */
+    /// The DPI value in the Exif header of the resulting image.
+    ///
+    /// - seealso: [Imgix Reference](https://www.imgix.com/docs/reference/format#param-dpi)
     public var DPI: Int? {
         get { return storage[.dpi] as? Int }
         set { storage[.dpi] = newValue }
     }
 
-    /**
-     Enables or disables lossless compression. Only available when using
-     certain formats.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/format#param-lossless)
-     */
+    /// Enables or disables lossless compression. Only available when using
+    /// certain formats.
+    ///
+    /// - seealso: [Imgix Reference](https://www.imgix.com/docs/reference/format#param-lossless)
     public var lossless: Bool? {
         get { return storage[.lossless] as? Bool }
         set { storage[.lossless] = newValue }
     }
 
-    /**
-     Controls the output quality of lossy file formats.
-
-     Values are clamped to the range of `0...100`.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/format#param-q)
-     */
+    /// Controls the output quality of lossy file formats. Values are clamped to
+    /// the range `0...100`.
+    ///
+    /// - seealso: [Imgix Reference](https://www.imgix.com/docs/reference/format#param-q)
     public var quality: Int? {
         get { return storage[.quality] as? Int }
         set { storage[.quality] = newValue?.clamped(to: 0...100) }
     }
 
-    /**
-     Limits the amount of colors in a picture using color quantization, which
-     is a process that reduces the amount of distinct colors in an image while
-     maintaining a visually-similar image.
-
-     Values are clamped to the range of `2...256`.
-
-     - seealso:
-     [Imgix API Reference](https://www.imgix.com/docs/reference/format#param-colorquant)
-     */
+    /// Limits the amount of colors in a picture using color quantization, which
+    /// is a process that reduces the amount of distinct colors in an image
+    /// while maintaining a visually-similar image.
+    ///
+    /// - seealso: [Imgix Reference](https://www.imgix.com/docs/reference/format#param-colorquant)
     public var colorQuantization: Int? {
         get { return storage[.colorQuantization] as? Int }
         set { storage[.colorQuantization] = newValue?.clamped(to: 2...256) }
@@ -471,9 +391,11 @@ extension ImageOptions {
 }
 
 // MARK: - Background Options
+
 extension ImageOptions {
+
     /// The background color to use when transparency is encountered. This color
-    /// is also used when using `FitMode.Fill`.
+    /// is also used when using `FitMode.fill`.
     ///
     /// - seealso: [Imgix API Reference](https://www.imgix.com/docs/reference/background#param-bg)
     public var backgroundColor: Color? {
@@ -500,8 +422,8 @@ extension ImageOptions {
 
 // MARK: - Equatable
 
-extension ImageOptions: Equatable {}
-
-public func ==(lhs: ImageOptions, rhs: ImageOptions) -> Bool {
-    return lhs.queryItems == rhs.queryItems
+extension ImageOptions: Equatable {
+    public static func == (lhs: ImageOptions, rhs: ImageOptions) -> Bool {
+        return lhs.queryItems == rhs.queryItems
+    }
 }

--- a/Iris/ImageOptions.swift
+++ b/Iris/ImageOptions.swift
@@ -402,6 +402,11 @@ extension ImageOptions {
         get { return storage[.backgroundColor] as? Color }
         set { storage[.backgroundColor] = newValue }
     }
+}
+
+// MARK: - Text Options
+
+extension ImageOptions {
 
     /// Sets the color of the text.
     ///

--- a/Iris/ImageOptions.swift
+++ b/Iris/ImageOptions.swift
@@ -148,7 +148,7 @@ public struct ImageOptions {
             items.append(queryItem(forKey: .format, value: value.rawValue))
         }
 
-        if let value = DPI {
+        if let value = dpi {
             items.append(queryItem(forKey: .dpi, value: String(value)))
         }
 
@@ -365,7 +365,7 @@ extension ImageOptions {
     /// The DPI value in the Exif header of the resulting image.
     ///
     /// - seealso: [Imgix Reference](https://www.imgix.com/docs/reference/format#param-dpi)
-    public var DPI: Int? {
+    public var dpi: Int? {
         get { return storage[.dpi] as? Int }
         set { storage[.dpi] = newValue }
     }

--- a/Iris/ImageOptions.swift
+++ b/Iris/ImageOptions.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2015 HODINKEE. All rights reserved.
 //
 
-import Foundation
-
 public struct ImageOptions {
 
     // MARK: - Types

--- a/Iris/ImageOptions.swift
+++ b/Iris/ImageOptions.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct ImageOptions: Equatable {
+public struct ImageOptions {
 
     // MARK: - Types
 
@@ -499,6 +499,8 @@ public struct ImageOptions: Equatable {
         return items
     }
 }
+
+extension ImageOptions: Equatable {}
 
 public func ==(lhs: ImageOptions, rhs: ImageOptions) -> Bool {
     return lhs.queryItems == rhs.queryItems

--- a/Iris/NSColor.swift
+++ b/Iris/NSColor.swift
@@ -8,8 +8,6 @@
 
 #if os(macOS)
 
-import AppKit
-
 public typealias Color = NSColor
 
 extension NSColor {

--- a/Iris/NSColor.swift
+++ b/Iris/NSColor.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2017 HODINKEE. All rights reserved.
 //
 
+#if os(macOS)
+
 import AppKit
 
 public typealias Color = NSColor
@@ -28,3 +30,5 @@ extension NSColor {
         return String(format: "%02X%02X%02X%02X", ((Int)(a * 255)), ((Int)(r * 255)), ((Int)(g * 255)), ((Int)(b * 255)))
     }
 }
+
+#endif // os(macOS)

--- a/Iris/NSURL+Iris.swift
+++ b/Iris/NSURL+Iris.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2015 HODINKEE. All rights reserved.
 //
 
-import Foundation
-
 extension URL {
 
     /// Applies the given image options to the receiver.

--- a/Iris/SigningOptions.swift
+++ b/Iris/SigningOptions.swift
@@ -8,27 +8,21 @@
 
 import Foundation
 
-public struct SigningOptions: Equatable {
+public struct SigningOptions {
 
     // MARK: - Properties
 
-    /**
-     The host pertaining to an Imgix source.
-    
-     Example: `hodinkee.imgix.net`
-    */
+    /// The host pertaining to an Imgix source.
+    ///
+    /// Example: `hodinkee.imgix.net`
     public var host: String
 
-    /**
-     The alphanumeric "Secure URL Token" pertaining to an Imgix source.
-
-     Example: `hodinkee.imgix.net`
-    */
+    /// The alphanumeric "Secure URL Token" pertaining to an Imgix source.
+    ///
+    /// Example: `hodinkee.imgix.net`
     public var token: String
 
-    /**
-     Controls whether or not to use HTTPS when requesting the image.
-    */
+    /// Controls whether or not to use HTTPS when requesting the image.
     public var secure: Bool
 
 
@@ -41,6 +35,8 @@ public struct SigningOptions: Equatable {
     }
 }
 
-public func ==(lhs: SigningOptions, rhs: SigningOptions) -> Bool {
-    return (lhs.host == rhs.host) && (lhs.token == rhs.token) && (lhs.secure == rhs.secure)
+extension SigningOptions: Equatable {
+    public static func == (lhs: SigningOptions, rhs: SigningOptions) -> Bool {
+        return (lhs.host == rhs.host) && (lhs.token == rhs.token) && (lhs.secure == rhs.secure)
+    }
 }

--- a/Iris/SigningOptions.swift
+++ b/Iris/SigningOptions.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2015 HODINKEE. All rights reserved.
 //
 
-import Foundation
-
 public struct SigningOptions {
 
     // MARK: - Properties

--- a/Iris/UIColor.swift
+++ b/Iris/UIColor.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2017 HODINKEE. All rights reserved.
 //
 
+#if os(iOS) || os(tvOS)
+
 import UIKit
 
 public typealias Color = UIColor
@@ -26,3 +28,5 @@ extension UIColor {
         return String(format: "%02X%02X%02X%02X", ((Int)(a * 255)), ((Int)(r * 255)), ((Int)(g * 255)), ((Int)(b * 255)))
     }
 }
+
+#endif // os(iOS) || os(tvOS)

--- a/Iris/UIColor.swift
+++ b/Iris/UIColor.swift
@@ -8,8 +8,6 @@
 
 #if os(iOS) || os(tvOS)
 
-import UIKit
-
 public typealias Color = UIColor
 
 extension UIColor {

--- a/Tests/ImageOptionsTests.swift
+++ b/Tests/ImageOptionsTests.swift
@@ -251,7 +251,7 @@ final class ImageOptionsTests: XCTestCase {
     }
 
     func testImageOptionsDPI() {
-        imageOptions.DPI = 320
+        imageOptions.dpi = 320
         XCTAssertEqual(queryItems, [URLQueryItem(name: "dpi", value: "320")])
     }
 

--- a/Tests/ImageOptionsTests.swift
+++ b/Tests/ImageOptionsTests.swift
@@ -301,6 +301,8 @@ final class ImageOptionsTests: XCTestCase {
         XCTAssertEqual(queryItems, [URLQueryItem(name: "txtsize", value: "16.0")])
     }
 
+    // MARK: - Text Options
+
     #if os(iOS) || os(tvOS)
     func testImageOptionsTextColor() {
         imageOptions.textColor = UIColor(red: 0.2, green: 0.4, blue: 0.6, alpha: 0.5)


### PR DESCRIPTION
This patch switches to using a `Dictionary` for backing value storage instead of ivars. This allows for more efficient memory allocation for relatively vanilla instances of `ImageOptions`.